### PR TITLE
Update Mews Demo & Production PlatformAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Sie sollten in Ihrer `config.json` solche Einträge sehen. Die Reihenfolge der E
 
 ```json
 {
-    "PlatformAddress": "https://demo.mews.li",
+    "PlatformAddress": "https://api.mews-demo.com",
     "ClientToken": "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     "HoursAfterMidnight": 3,
     "TestStartTime": "22.06.2018 03:00",
@@ -135,7 +135,7 @@ Bitte tragen sie hier den *ClientToken* ein, welcher Ihnen von Mews (vermutlich 
 
 ### `PlatformAddress`
 
-Bitte tragen Sie hier `"https://www.mews.li"` ein.
+Bitte tragen Sie hier `"https://api.mews.com"` ein.
 
 ### `Hotels`
 
@@ -148,7 +148,7 @@ Zur besseren Übersicht ist es erlaubt, weitere Felder wie z.B. `Name` hinzuzuf�
 Am Ende wird Ihre `config.json` so aussehen:
 ```json
 {
-    "PlatformAddress": "https://www.mews.li",
+    "PlatformAddress": "https://api.mews.com",
     "ClientToken": "<geheimes ClientToken via email>",
     "HoursAfterMidnight": 3,
     "OutFolder": "C:\\SiDAP\\SiDAP-Client\\Upload\\Hoko",

--- a/mehr_config.py
+++ b/mehr_config.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse as datetime_parse
 import logging
 
 config_template = {
-    'PlatformAddress': "https://demo.mews.li",
+    'PlatformAddress': "https://api.mews-demo.com",
     'ClientToken': "E0D439EE522F44368DC78E1BFB03710C-D24FB11DBE31D4621C4817E028D9E1D",
     'OutFolder': None,
     'HoursAfterMidnight': 3,


### PR DESCRIPTION
The old URLs are getting deprecated. I just came across the German README.md that could be set in the Config file, so I'm proposing the URL changes. 

for reference:
new Demo URL: https://github.com/MewsSystems/gitbook-connector-api/blob/develop/guidelines/environments.md#demo-environments
new Prod URL: https://github.com/MewsSystems/gitbook-connector-api/blob/develop/guidelines/environments.md#production-environment

Question: Is it enough for Mews to notify the properties using the HoKo reporter to update the PlatformAddress in their config file? I see in our logentries that some properties have already changed the PlatformAddress

Many thanks! 
Sylvia